### PR TITLE
verify test file

### DIFF
--- a/.github/workflows/terraform-tests.yml
+++ b/.github/workflows/terraform-tests.yml
@@ -43,7 +43,7 @@ jobs:
 
       # Step 4: Lint Terraform code
       - name: Run tflint
-        uses: tflint
+        run: tflint
 
     #   # Step 5: Run tfsec for security checks
     #   - name: Run tfsec for security

--- a/main.tf
+++ b/main.tf
@@ -36,7 +36,7 @@ module "ec2" {   # ec2 module
   subnet_id          = module.vpc.subnet_id
   instance_name      = "${each.key}-test-instance" 
   bucket_name        = module.s3_bucket.bucket_name
-  iam_instance_profile= "${each.key}_${module.iam_policies.iam_instance_profile}"
+  iam_instance_profile= "${each.key}-EC2InstanceProfile"
   additional_user_data = each.value
   each_key=  "${each.key}"
 }

--- a/modules/policies/main.tf
+++ b/modules/policies/main.tf
@@ -69,7 +69,7 @@ resource "aws_iam_role" "target_ec2_service_role" {
 }
 
 # Attach S3 Policy to the Role for target instance
-resource "aws_iam_role_policy_attachment" "user_policy_attachment" {
+resource "aws_iam_role_policy_attachment" "target_user_policy_attachment" {
   role       = aws_iam_role.target_ec2_service_role.name
   policy_arn = aws_iam_policy.user_s3_policy.arn
 }
@@ -129,7 +129,7 @@ resource "aws_iam_role" "monitor_ec2_service_role" {
 }
 
 # Attach S3 Policy to the Role for monitor instance
-resource "aws_iam_role_policy_attachment" "user_policy_attachment" {
+resource "aws_iam_role_policy_attachment" "monitor_user_policy_attachment" {
   role       = aws_iam_role.monitor_ec2_service_role.name
   policy_arn = aws_iam_policy.user_s3_policy.arn
 }

--- a/modules/policies/outputs.tf
+++ b/modules/policies/outputs.tf
@@ -1,7 +1,7 @@
-output "target-iam_instance_profile" {
+output "target_iam_instance_profile" {
   value = aws_iam_instance_profile.target_ec2_instance_profile
 }
 
-output "monitor-iam_instance_profile" {
+output "monitor_iam_instance_profile" {
   value = aws_iam_instance_profile.monitor_ec2_instance_profile
 }

--- a/modules/policies/outputs.tf
+++ b/modules/policies/outputs.tf
@@ -1,3 +1,7 @@
 output "target-iam_instance_profile" {
-  value = aws_iam_instance_profile.ec2_instance_profile.name
+  value = aws_iam_instance_profile.target_ec2_instance_profile
+}
+
+output "monitor-iam_instance_profile" {
+  value = aws_iam_instance_profile.monitor_ec2_instance_profile
 }

--- a/modules/policies/outputs.tf
+++ b/modules/policies/outputs.tf
@@ -1,7 +1,7 @@
-output "target_iam_instance_profile" {
-  value = aws_iam_instance_profile.target_ec2_instance_profile
-}
+# output "iam_instance_profile" {
+#   value = aws_iam_instance_profile.target_ec2_instance_profile
+# }
 
-output "monitor_iam_instance_profile" {
-  value = aws_iam_instance_profile.monitor_ec2_instance_profile
-}
+# output "monitor_iam_instance_profile" {
+#   value = aws_iam_instance_profile.monitor_ec2_instance_profile
+# }

--- a/variables.tf
+++ b/variables.tf
@@ -10,3 +10,5 @@ variable "instance_type" {
   default = "t2.micro"
   type =string
 }
+
+


### PR DESCRIPTION
fixed instances being assigned unique instance profiles issue by no longer using an output from policy module.
verifying it pasts tests, and that test file is run as expected.